### PR TITLE
Removing band aid for thread_local

### DIFF
--- a/cmake/nwx_python_mods.cmake
+++ b/cmake/nwx_python_mods.cmake
@@ -99,17 +99,6 @@ function(cppyy_make_python_package)
     set(init_file "${init_file}    if p and p!=\"\":\n")
     set(init_file "${init_file}        cppyy.add_include_path(p)\n")
     #---------------------------------------------------------------------------
-    #--Temporary band-aid for MADworld MPI threads fixed in future cling/cppyy---
-    #---------------------------------------------------------------------------
-    if (install_data_MPI)
-        set(init_file "${init_file}cppyy.cppdef(\"\"\"\\ \n")
-        set(init_file "${init_file}\#define thread_local\n")
-        set(init_file "${init_file}\#define is_server_thread \*_cling_is_server_thread()\n")
-        set(init_file "${init_file}\#include \"${MADNESS_SOURCE_DIR}/src/madness/world/worldrmi.h\"\n")
-        set(init_file "${init_file}\#undef thread_local\n")
-        set(init_file "${init_file}\"\"\")\n")
-    endif()
-    #---------------------------------------------------------------------------
     #--End of temporary band-aid------------------------------------------------
     #---------------------------------------------------------------------------
     set(init_file "${init_file}cppyy.include(\"${python_defines_file}\")\n")

--- a/cmake/nwx_python_mods.cmake
+++ b/cmake/nwx_python_mods.cmake
@@ -98,9 +98,6 @@ function(cppyy_make_python_package)
     set(init_file "${init_file}for p in paths:\n")
     set(init_file "${init_file}    if p and p!=\"\":\n")
     set(init_file "${init_file}        cppyy.add_include_path(p)\n")
-    #---------------------------------------------------------------------------
-    #--End of temporary band-aid------------------------------------------------
-    #---------------------------------------------------------------------------
     set(init_file "${init_file}cppyy.include(\"${python_defines_file}\")\n")
     set(init_file "${init_file}headers = \"${include_headers}\".split(';')\n")
     set(init_file "${init_file}for inc in headers:\n")


### PR DESCRIPTION
- [ ] Breaking change
- [ ] Feature
- [ X] Patch

**Brief Description**

Cleaning up a remnant related to thread_local, that was driven by cppyy using an older version of llvm/cling/clang. This is now resolved in the cppyy 3.0.0 version.
