### PR TITLE
Add dummy get_cpp for CPP compatibility  when moving over to CMaize

### DIFF
--- a/cmake/get_cpp.cmake
+++ b/cmake/get_cpp.cmake
@@ -1,0 +1,4 @@
+if(NOT CMAIZE_GITHUB_TOKEN)
+  set( CMAIZE_GITHUB_TOKEN "${CPP_GITHUB_TOKEN}" )
+endif()
+include(get_cmaize)


### PR DESCRIPTION
**PR Type**
- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
<!---
    In a couple sentences, describe what this pull request will accomplish. If
    there is a corresponding issue please link to it with
    [closing words](
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-
        using-a-keyword)
    as appropriate. If the goal is more complicated than can be articulated in
    a few sentences, please first open an issue and explain it in detail
    there.
--->

[latest](https://github.com/NWChemEx-Project/NWXCMake/commit/72660c5a0a86bf6424fb1cd86989bca20ce76a5d) commit is API breaking (`CMakePP` -> `CMaize`), this PR adds a compatibility patch to allow interoperability with older `CMakePP`usage (`get_cpp` forwards to `get_cmaize` and `CPP_GITHUB_TOKEN` -> `CMAIZE_GITHUB_TOKEN`)
