### PR TITLE
Use CMaize to get a list of public headers

### DIFF
--- a/cmake/nwx_python_mods.cmake
+++ b/cmake/nwx_python_mods.cmake
@@ -16,7 +16,7 @@
 # should be placed next to the shared library created by that target. This
 # function assumes the target's:
 #
-# * public header files are in the ``PUBLIC_HEADER`` property
+# * public header files are obtained through CMaize BuildTarget `includes` attribute 
 # * include paths are in the ``INTERFACE_INCLUDE_DIRECTORIES`` property
 # * dependencies are targets and in the ``INTERFACE_LINK_LIBRARIES`` property
 #
@@ -64,8 +64,17 @@ function(cppyy_make_python_package)
     #---------------------------------------------------------------------------
     #--------------------------Get headers to include---------------------------
     #---------------------------------------------------------------------------
-    get_target_property(include_headers ${install_data_PACKAGE} PUBLIC_HEADER)
-    get_filename_component(header_PREFIX ${CMAKE_CURRENT_SOURCE_DIR} NAME_WE)
+    # Get the currently active CMaize project
+    cpp_get_global(cmaize_project CMAIZE_PROJECT)
+
+    # Get the desired CMaize target by name (in NWChemEx, this is usually the current project name, too)
+    CMaizeProject(get_target "${cmaize_project}" tgt ${PROJECT_NAME})
+
+    # Get the CMaize BuildTarget `includes` attribute, which is a list of include files for the target
+    BuildTarget(GET "${tgt}" include_headers includes)
+
+    # Print the include file list to make sure everything worked
+    message(DEBUG "include_file_list: ${include_headers}")
     #---------------------------------------------------------------------------
     #-----------------Blacklist headers we do not want to expose----------------
     #---------------------------------------------------------------------------


### PR DESCRIPTION
cppyy_make_python_package function was depending on `PUBLIC_HEADER` to get a list of header files. Since CMaize is not setting this property anymore we switch to using CMaize BuildTarget `includes` attribute as suggested by @zachcran. Fixes issue #12.

<!---
    This is a comment. So are other lines like it. No need to delete them
    before submitting your PR. If you need help on submitting a PR please
    see our tutorial at https://nwchemex-project.github.io/.github/resources/github/pull_request.html
--->

<!---
    As of 12/7/2022 GitHub does not allow multiple PR templates. Our solution
    is to create one master PR template for all use cases, please delete the
    use cases which are not relevant for your PR. Sorry about the extra step.
--->

<!---
    General PR Questions
    ====================
    Please answer all questions in this section for all PRs.
--->

**PR Type**
<!---
    Please check the corresponding box.

    "Breaking change" is a PR which will break existing user-facing code. These
    types of PRs must be discussed in advance. They may be very small, or very
    extensive PRs depending on the change.

    A "feature" is a PR which adds a major new capability, massively overhauls
    an existing feature, writes entirely new documentation pages, or optimizes
    an extensive algorithm. Features usually take at least a week to implement.

    A "patch" is a PR which touches relatively few lines of code. Patches
    usually address bugs, minor performance issues, typos, clarify
    documentation, etc. Most patches are ready to go in a day or two.
--->

- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
<!---
    In a couple sentences, describe what this pull request will accomplish. If
    there is a corresponding issue please link to it with
    [closing words](
        https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue#linking-a-pull-request-to-an-issue-
        using-a-keyword)
    as appropriate. If the goal is more complicated than can be articulated in
    a few sentences, please first open an issue and explain it in detail
    there.
--->

**Not In Scope**
<!---
    Some features have obvious extensions or use cases. If you're only targeting
    a specific use case and don't want to worry about other use cases in this
    PR please make that clear. As appropriate, open an issue for anything not in scope that will need to be or
    could be done in the future.
--->



**PR Checklist**

<!---
    This checklist is meant for developers who are part of the NWChemEx-Project
    organization. If you are an outside collaborator, who only occasionally
    contributes little tweaks, we're just happy to get your contribution. The
    reviewers will happily make any changes needed to bring your contribution
    up to snuff.

    For developers who are part of the organization, and outside collaborators making frequent or large contributions, know that the NWChemEx-Project
    organization strives to be an exemplar of code quality. Unless you have
    advance approval, your PR will not be merged until all relevant items on the
    checklist have been addressed. That said, if you're new, we're certainly
    willing to help out, answer questions, and point you to the right resources.
--->

- [ ] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [ ] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [ ] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)

