### PR TITLE
Update python test macro

### DIFF
--- a/cmake/nwx_pybind11.cmake
+++ b/cmake/nwx_pybind11.cmake
@@ -153,6 +153,7 @@ function(nwx_pybind11_tests npt_name npt_driver)
     )
 
     if("${BUILD_TESTING}")
+        include(CTest)
         # Build the PYTHONPATH for the test
         # N.B. This presently assumes we're building the Python submodules we
         #      need or they are installed in ${NWX_MODULE_DIRECTORY}


### PR DESCRIPTION
Right now the `nwx_pybind11_tests` macro did not include `include(CTest)` which is necessary for using CTest. This PR fixes that.