### PR TITLE
Extend PYTHONPATH in Python Tests

### DIFF
--- a/cmake/nwx_pybind11.cmake
+++ b/cmake/nwx_pybind11.cmake
@@ -172,6 +172,9 @@ function(nwx_pybind11_tests npt_name npt_driver)
             set(_npt_dep_dir "${CMAKE_BINARY_DIR}/_deps/${_npt_submod}-build")
             set(_npt_py_path "${_npt_py_path}:${_npt_dep_dir}")
         endforeach()
+        if(NOT "${NWX_PYTHON_EXTERNALS}" STREQUAL "")
+            set(_npt_py_path "${_npt_py_path}:${NWX_PYTHON_EXTERNALS}")
+        endif()
 
         add_test(
             NAME "${npt_name}"


### PR DESCRIPTION
**PR Type**

- [ ] Breaking change
- [x] Feature
- [ ] Patch

**Brief Description**
`nwx_pybind11_tests` will use the variable `NWX_PYTHON_EXTERNALS` to extend the `PYTHONPATH` in the resulting unit tests, allowing for the test to find python modules outside of `NWX_MODULE_DIRECTORY` and the current build.

**Not In Scope**

**PR Checklist**
- [x] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [x] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [x] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)
