### PR TITLE
`nwx_pybind11.cmake` patch to find python

### DIFF
--- a/cmake/nwx_pybind11.cmake
+++ b/cmake/nwx_pybind11.cmake
@@ -60,6 +60,8 @@ function(nwx_add_pybind11_module npm_module_name)
         )
     endif()
 
+    find_package(Python COMPONENTS Interpreter Development)
+
     cmaize_find_or_build_dependency(
         pybind11
         URL github.com/pybind/pybind11


### PR DESCRIPTION
**PR Type**

- [ ] Breaking change
- [ ] Feature
- [x] Patch

**Brief Description**
Adds an explicit `find_package(Python)` call to `nwx_add_pybind11_module` to handle cases where the `Python::Python` target wasn't being found.

**Not In Scope**

**PR Checklist**

- [x] [Is documented](https://nwchemex-project.github.io/.github/documenting/index.html)
- [x] [Is tested](https://nwchemex-project.github.io/.github/testing/index.html)
- [x] [Adheres to applicable organization standards](https://nwchemex-project.github.io/.github/conventions/index.html)
