### PR TITLE
Update get_cmaize.cmake

### DIFF
--- a/cmake/get_cmaize.cmake
+++ b/cmake/get_cmaize.cmake
@@ -30,6 +30,7 @@ function(get_cmaize)
     FetchContent_Declare(
         cmaize
         GIT_REPOSITORY https://github.com/CMakePP/CMakePackagingProject
+        GIT_TAG 3cef972afa573c8d0c56a832341b8b20646f3d16
     )
     FetchContent_MakeAvailable(cmaize)
 


### PR DESCRIPTION
This pins the CMaize version to current master because I'm about to start doing some CMaize development and, while I shouldn't be changing APIs/behavior,  I want to guarantee I'm not breaking NWChemEx.
