### PR TITLE
Pin pybind11 version

### DIFF
--- a/cmake/nwx_pybind11.cmake
+++ b/cmake/nwx_pybind11.cmake
@@ -77,6 +77,7 @@ function(nwx_find_pybind11)
     cmaize_find_or_build_dependency(
         pybind11
         URL github.com/pybind/pybind11
+        VERSION v3.0.2
         BUILD_TARGET pybind11::headers
         FIND_TARGET pybind11::embed
         CMAKE_ARGS PYBIND11_INSTALL=ON


### PR DESCRIPTION
**Description**
Recent changes to pybind11's master branch broke a couple of our repos ([Integrals](https://github.com/NWChemEx/Integrals/actions/runs/23634458119), [ChemCache](https://github.com/NWChemEx/ChemCache/actions/runs/23634409256), and [SCF](https://github.com/NWChemEx/SCF/actions/runs/23634329744)). We probably should have pinned the pybind11 version already anyway, so this pins it to 3.0.2.