### PR TITLE
Fix broken FetchContent: point utilities/parallelzone at master

### DIFF
--- a/cmake/dependencies/parallelzone.cmake
+++ b/cmake/dependencies/parallelzone.cmake
@@ -18,7 +18,7 @@ include(FetchContent)
 FetchContent_Declare(
     parallelzone
     GIT_REPOSITORY https://github.com/NWChemEx/ParallelZone
-    GIT_TAG        build_overhaul
+    GIT_TAG        master
 )
 
 if(SKBUILD)

--- a/cmake/dependencies/utilities.cmake
+++ b/cmake/dependencies/utilities.cmake
@@ -18,7 +18,7 @@ include(FetchContent)
 FetchContent_Declare(
     utilities
     GIT_REPOSITORY https://github.com/NWChemEx/Utilities
-    GIT_TAG        build_overhaul
+    GIT_TAG        master
 )
 
 if(SKBUILD)


### PR DESCRIPTION
## Summary
**Urgent -- currently breaking CI on every repo that transitively depends on Utilities or ParallelZone** (confirmed on NWChemEx/TensorWrapper#252 and NWChemEx/PluginPlay#388: `CMake Error ... Failed to checkout tag: 'build_overhaul'`).

- `NWChemEx/Utilities` and `NWChemEx/ParallelZone` have both completed their CI/dependency migration and merged into `master`. This org has `delete_branch_on_merge` enabled, so both `build_overhaul` branches were deleted the instant those PRs merged.
- `cmake/dependencies/{utilities,parallelzone}.cmake` still pinned `GIT_TAG build_overhaul`, per the original plan to hold that pin until every ecosystem repo finished migrating -- that plan didn't account for branches disappearing incrementally as each repo merges, one at a time, well before the last one does.
- Fix: flip only these two entries to `master` now, since their content is actually there. The remaining entries (chemist, simde, chemcache, integrals, nux, nwchemex, pluginplay, tensorwrapper) correctly stay on `build_overhaul` -- `master` doesn't have their migrated content yet, so flipping them now would fetch stale content instead.

Going forward, each repo's `cmake/dependencies/<repo>.cmake` entry will flip to `master` in the same wave that repo's own migration PR merges, rather than batching all of them into one cleanup at the end.

## Test plan
- [ ] Re-run TensorWrapper#252 and PluginPlay#388's `test_cmake_build`/`test_pip_build` jobs once this merges, confirm the FetchContent failure is gone