### PR TITLE
Fix broken FetchContent: point wtf at master

### DIFF
--- a/cmake/dependencies/wtf.cmake
+++ b/cmake/dependencies/wtf.cmake
@@ -18,7 +18,7 @@ include(FetchContent)
 FetchContent_Declare(
     wtf
     GIT_REPOSITORY https://github.com/nwchemex/WeaklyTypedFloat
-    GIT_TAG        "python_bindings"
+    GIT_TAG        "master"
 )
 
 if(SKBUILD)


### PR DESCRIPTION
## Summary
Same bug class as #64, one I missed there because it's a differently-named branch, not \`build_overhaul\`.

- \`NWChemEx/WeaklyTypedFloat\`'s PR #11 (\`python_bindings -> master\`) merged, and this org's \`delete_branch_on_merge\` setting deleted \`python_bindings\` the moment it did.
- \`cmake/dependencies/wtf.cmake\` still pinned \`GIT_TAG "python_bindings"\`, breaking FetchContent for anything that depends on \`wtf\` -- confirmed on TensorWrapper#252 (\`Failed to checkout tag: 'python_bindings'\`), the same failure mode as #64.
- Swept every other \`cmake/dependencies/*.cmake\` entry's \`GIT_TAG\` against the live branch list: the remaining 8 (chemcache, chemist, integrals, nux, nwchemex, pluginplay, simde, tensorwrapper) all still correctly point at branches that exist.

## Test plan
- [ ] Re-run TensorWrapper#252's failing jobs once this merges, confirm FetchContent succeeds