### PR TITLE
Fix broken FetchContent: point pluginplay at master

### DIFF
--- a/cmake/dependencies/pluginplay.cmake
+++ b/cmake/dependencies/pluginplay.cmake
@@ -18,7 +18,7 @@ include(FetchContent)
 FetchContent_Declare(
     pluginplay
     GIT_REPOSITORY https://github.com/NWChemEx/PluginPlay
-    GIT_TAG        build_overhaul
+    GIT_TAG        master
 )
 
 if(SKBUILD)


### PR DESCRIPTION
## Summary
Same bug class as #64 and #65: \`NWChemEx/PluginPlay\`'s migration PR (#388) merged, and this org's \`delete_branch_on_merge\` setting deleted its \`build_overhaul\` branch the moment it did. Flips \`cmake/dependencies/pluginplay.cmake\`'s \`GIT_TAG\` to \`master\`, which now has the migrated content.

I'll do the same for \`tensorwrapper.cmake\` as soon as TensorWrapper#252 finishes merging.