### PR TITLE
Fix broken FetchContent: point chemist at master

### DIFF
--- a/cmake/dependencies/chemist.cmake
+++ b/cmake/dependencies/chemist.cmake
@@ -18,7 +18,7 @@ include(FetchContent)
 FetchContent_Declare(
     chemist
     GIT_REPOSITORY https://github.com/NWChemEx/Chemist
-    GIT_TAG        build_overhaul
+    GIT_TAG        master
 )
 
 if(SKBUILD)


### PR DESCRIPTION
Same bug class as #64/#65/#66/#67. Flips `cmake/dependencies/chemist.cmake`'s `GIT_TAG` to `master` now that Chemist's migration PR (#469) merged and its `build_overhaul` branch was auto-deleted.