### PR TITLE
Fix broken FetchContent: point simde at master

### DIFF
--- a/cmake/dependencies/simde.cmake
+++ b/cmake/dependencies/simde.cmake
@@ -18,7 +18,7 @@ include(FetchContent)
 FetchContent_Declare(
     simde
     GIT_REPOSITORY https://github.com/NWChemEx/SimDE
-    GIT_TAG        build_overhaul
+    GIT_TAG        master
 )
 
 if(SKBUILD)


### PR DESCRIPTION
SimDE#179 merged and delete_branch_on_merge removed build_overhaul, so simde.cmake's GIT_TAG must flip immediately.