### PR TITLE
Fix broken FetchContent: point nwchemex at master

### DIFF
--- a/cmake/dependencies/nwchemex.cmake
+++ b/cmake/dependencies/nwchemex.cmake
@@ -18,7 +18,7 @@ include(FetchContent)
 FetchContent_Declare(
     nwchemex
     GIT_REPOSITORY https://github.com/NWChemEx/NWChemEx
-    GIT_TAG        build_overhaul
+    GIT_TAG        master
 )
 
 if(SKBUILD)


### PR DESCRIPTION
NWChemEx#156 merged and delete_branch_on_merge removed build_overhaul, so nwchemex.cmake's GIT_TAG must flip immediately.