### PR TITLE
Use dynamic (hatch-vcs) versioning instead of a hardcoded version

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,15 +20,21 @@
 # (wheel) install bundles a copy of cmake/ inside the package.
 
 [build-system]
-requires = ["hatchling"]
+requires = ["hatchling", "hatch-vcs"]
 build-backend = "hatchling.build"
 
 [project]
 name = "nwchemex-nwxcmake"
-version = "0.1.0"
+dynamic = ["version"]
 description = "Shared NWChemEx CMake modules, discoverable from Python"
 license = { text = "Apache-2.0" }
 requires-python = ">=3.8"
+
+[tool.hatch.version]
+source = "vcs"
+
+[tool.hatch.version.raw-options]
+fallback_version = "0.0.0"
 
 [tool.hatch.build.targets.wheel]
 # The importable Python package lives under python/nwxcmake ...


### PR DESCRIPTION
## Summary
- `deploy_to_pypi` runs on every push to master, but `pyproject.toml` pinned `version = "0.1.0"`, so every deploy after the first successful publish failed with `400 Bad Request: File already exists`.
- Switches to `hatch-vcs` for dynamic, git-tag-derived versioning — the pure-Python (hatchling) equivalent of what every other NWChemEx repo does via setuptools_scm.

## Test plan
- [x] Built sdist + wheel locally in an isolated venv; version was correctly derived from git tags instead of the fixed `0.1.0`.
- [ ] Confirm the merge workflow publishes successfully to PyPI after this merges (the `tag-commit` job creates the new tag before `deploy_to_pypi` checks out, so the wheel picks it up).

🤖 Generated with [Claude Code](https://claude.com/claude-code)