### PR TITLE
Fail fast with a clear message when gau2grid's Python lacks numpy

### DIFF
--- a/cmake/dependencies/gau2grid.cmake
+++ b/cmake/dependencies/gau2grid.cmake
@@ -37,6 +37,37 @@ if(TARGET gau2grid::gg)
     return()
 endif()
 
+# gau2grid's own CMakeLists only requests `COMPONENTS Interpreter` (no
+# NumPy component) and never checks numpy is importable before wiring its
+# code generator up as a build-time add_custom_command. That means a plain
+# find_package(Python) can silently resolve to an interpreter without numpy
+# (e.g. the first one on PATH), and the failure only surfaces later, deep in
+# a custom command, as a raw Python traceback. Resolve and validate the
+# interpreter here instead, mirroring skbuild_python.cmake's FATAL_ERROR
+# pattern, so a missing numpy is a clear configure-time error.
+find_package(Python 3.6 REQUIRED COMPONENTS Interpreter)
+execute_process(
+    COMMAND "${Python_EXECUTABLE}" -c "import numpy"
+    RESULT_VARIABLE _gd_numpy_rc
+    OUTPUT_QUIET
+    ERROR_QUIET
+)
+if(NOT _gd_numpy_rc EQUAL 0)
+    message(FATAL_ERROR
+        "gau2grid's code generator requires numpy, but it is not "
+        "importable in the detected Python interpreter "
+        "(${Python_EXECUTABLE}). Install it there, e.g.:\n"
+        "    ${Python_EXECUTABLE} -m pip install numpy\n"
+        "or point CMake at a different interpreter with "
+        "-DPython_EXECUTABLE=/path/to/python."
+    )
+endif()
+unset(_gd_numpy_rc)
+
+# Pin gau2grid's own find_package(Python) to the exact interpreter just
+# validated above, so it can't silently re-resolve to a different one.
+set(Python_EXECUTABLE "${Python_EXECUTABLE}" CACHE FILEPATH "" FORCE)
+
 FetchContent_Declare(
     gau2grid
     GIT_REPOSITORY https://github.com/psi4/gau2grid

--- a/cmake/dependencies/gauxc.cmake
+++ b/cmake/dependencies/gauxc.cmake
@@ -126,5 +126,23 @@ FetchContent_MakeAvailable(gauxc)
 set(BUILD_TESTING "${_gd_bt_backup}" CACHE BOOL "" FORCE)
 unset(_gd_bt_backup)
 
+# GauXC and its transitively-fetched ExchCXX unconditionally add -Wall
+# -Wextra -Wpedantic -Wnon-virtual-dtor -Wshadow as PRIVATE compile options
+# to their own sources (gauxc-src/src/CMakeLists.txt,
+# exchcxx-src/src/CMakeLists.txt), with no option() to opt out. That floods
+# the build log with warnings from code we don't maintain. Append -w after
+# their own flags on each target: it's added later, so for GCC/Clang/
+# AppleClang it wins over their earlier -W* flags and silences the noise
+# for just these two targets' own compilation -- everything else (including
+# SCF's own code, since these are PRIVATE and don't propagate) is unaffected.
+foreach(_gd_noisy_target gauxc exchcxx)
+    if(TARGET ${_gd_noisy_target})
+        target_compile_options(${_gd_noisy_target} PRIVATE
+            $<$<AND:$<COMPILE_LANGUAGE:CXX>,$<CXX_COMPILER_ID:GNU,Clang,AppleClang>>:-w>
+        )
+    endif()
+endforeach()
+unset(_gd_noisy_target)
+
 set(_gd_target_gauxc "gauxc::gauxc")
 set(_gd_uses_fc FALSE)


### PR DESCRIPTION
gau2grid's own CMakeLists only requires COMPONENTS Interpreter and never checks numpy is importable before wiring its codegen up as a build-time custom command, so a plain find_package(Python) that lands on a numpy-less interpreter fails late with a cryptic traceback instead of a clear configure-time error. Resolve and validate the interpreter here, mirroring skbuild_python.cmake's FATAL_ERROR pattern, and pin gau2grid to the exact interpreter validated.


