### PR TITLE
now looks for pip installed packages

### DIFF
--- a/cmake/dependencies/chemcache.cmake
+++ b/cmake/dependencies/chemcache.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    chemcache
-    GIT_REPOSITORY https://github.com/NWChemEx/ChemCache
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::chemcache)
-else()
-    list(APPEND _gd_targets chemcache)
-endif()
+nwx_ecosystem_dependency(chemcache https://github.com/NWChemEx/ChemCache)

--- a/cmake/dependencies/chemist.cmake
+++ b/cmake/dependencies/chemist.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    chemist
-    GIT_REPOSITORY https://github.com/NWChemEx/Chemist
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::chemist)
-else()
-    list(APPEND _gd_targets chemist)
-endif()
+nwx_ecosystem_dependency(chemist https://github.com/NWChemEx/Chemist)

--- a/cmake/dependencies/integrals.cmake
+++ b/cmake/dependencies/integrals.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    integrals
-    GIT_REPOSITORY https://github.com/NWChemEx/Integrals
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::integrals)
-else()
-    list(APPEND _gd_targets integrals)
-endif()
+nwx_ecosystem_dependency(integrals https://github.com/NWChemEx/Integrals)

--- a/cmake/dependencies/nux.cmake
+++ b/cmake/dependencies/nux.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    nux
-    GIT_REPOSITORY https://github.com/NWChemEx/NUX
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::nux)
-else()
-    list(APPEND _gd_targets nux)
-endif()
+nwx_ecosystem_dependency(nux https://github.com/NWChemEx/NUX)

--- a/cmake/dependencies/nwchemex.cmake
+++ b/cmake/dependencies/nwchemex.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    nwchemex
-    GIT_REPOSITORY https://github.com/NWChemEx/NWChemEx
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::nwchemex)
-else()
-    list(APPEND _gd_targets nwchemex)
-endif()
+nwx_ecosystem_dependency(nwchemex https://github.com/NWChemEx/NWChemEx)

--- a/cmake/dependencies/parallelzone.cmake
+++ b/cmake/dependencies/parallelzone.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    parallelzone
-    GIT_REPOSITORY https://github.com/NWChemEx/ParallelZone
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::parallelzone)
-else()
-    list(APPEND _gd_targets parallelzone)
-endif()
+nwx_ecosystem_dependency(parallelzone https://github.com/NWChemEx/ParallelZone)

--- a/cmake/dependencies/pluginplay.cmake
+++ b/cmake/dependencies/pluginplay.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    pluginplay
-    GIT_REPOSITORY https://github.com/NWChemEx/PluginPlay
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::pluginplay)
-else()
-    list(APPEND _gd_targets pluginplay)
-endif()
+nwx_ecosystem_dependency(pluginplay https://github.com/NWChemEx/PluginPlay)

--- a/cmake/dependencies/scf.cmake
+++ b/cmake/dependencies/scf.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    scf
-    GIT_REPOSITORY https://github.com/NWChemEx/SCF
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::scf)
-else()
-    list(APPEND _gd_targets scf)
-endif()
+nwx_ecosystem_dependency(scf https://github.com/NWChemEx/SCF)

--- a/cmake/dependencies/simde.cmake
+++ b/cmake/dependencies/simde.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    simde
-    GIT_REPOSITORY https://github.com/NWChemEx/SimDE
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::simde)
-else()
-    list(APPEND _gd_targets simde)
-endif()
+nwx_ecosystem_dependency(simde https://github.com/NWChemEx/SimDE)

--- a/cmake/dependencies/tensorwrapper.cmake
+++ b/cmake/dependencies/tensorwrapper.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    tensorwrapper
-    GIT_REPOSITORY https://github.com/NWChemEx/TensorWrapper
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::tensorwrapper)
-else()
-    list(APPEND _gd_targets tensorwrapper)
-endif()
+nwx_ecosystem_dependency(tensorwrapper https://github.com/NWChemEx/TensorWrapper)

--- a/cmake/dependencies/utilities.cmake
+++ b/cmake/dependencies/utilities.cmake
@@ -13,16 +13,6 @@
 # limitations under the License.
 
 include_guard()
-include(FetchContent)
+include(nwx_ecosystem_dependency)
 
-FetchContent_Declare(
-    utilities
-    GIT_REPOSITORY https://github.com/NWChemEx/Utilities
-    GIT_TAG        master
-)
-
-if(SKBUILD)
-    list(APPEND _gd_targets nwx::utilities)
-else()
-    list(APPEND _gd_targets utilities)
-endif()
+nwx_ecosystem_dependency(utilities https://github.com/NWChemEx/Utilities)

--- a/cmake/get_dependencies.cmake
+++ b/cmake/get_dependencies.cmake
@@ -18,9 +18,12 @@ include(FetchContent)
 function(get_dependencies)
     set(_gd_targets)
     set(_gd_fc_names)
-    if(SKBUILD)
-        include(dependencies/skbuild_python)
-    endif()
+    # Populate NWX_VENV_SITE_PACKAGES/CMAKE_PREFIX_PATH from the ambient
+    # Python's site-packages unconditionally (not just when scikit-build-core
+    # itself is driving the build via SKBUILD) so find_package() below can
+    # locate a pip-installed nwchemex-* wheel even during a plain, ambient
+    # `cmake -Bbuild` configure (e.g. the CI cmake_build action).
+    include(dependencies/skbuild_python)
 
     # Dependencies found via find_package() below (gauxc, libxc, gau2grid,
     # ...) must only ever resolve against CMAKE_PREFIX_PATH (the active

--- a/cmake/nwx_ecosystem_dependency.cmake
+++ b/cmake/nwx_ecosystem_dependency.cmake
@@ -1,0 +1,64 @@
+# Copyright 2026 NWChemEx-Project
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+include_guard()
+include(FetchContent)
+
+# nwx_ecosystem_dependency(name git_repository)
+#
+# Shared body for every NWChemEx-owned dependency in dependencies/*.cmake
+# (pluginplay, chemist, tensorwrapper, utilities, parallelzone, simde,
+# integrals, nux, chemcache, nwchemex). Each of those repos also publishes a
+# real wheel to PyPI, so:
+#
+#   1. Reuse a previously-installed wheel from the active venv's
+#      site-packages (NWX_VENV_SITE_PACKAGES) if one exists, instead of
+#      re-cloning and rebuilding <name> from source every time. Scoped to
+#      exactly that directory (NO_DEFAULT_PATH) so this can never
+#      accidentally match an unrelated system-wide install.
+#   2. unset(<name>_DIR CACHE) first: <name>_DIR is itself a cache variable,
+#      so find_package() would otherwise short-circuit on (and trust) a
+#      stale/unrelated value left behind by an earlier, unscoped
+#      find_package() call for the same name -- either from a different
+#      dependency fetched earlier in this same configure, or from a
+#      previous configure of this same build directory.
+#   3. Fall back to FetchContent (git master) only if no installed wheel was
+#      found.
+#
+# Must be a macro, not a function: this is include()'d from inside
+# get_dependencies()'s foreach loop (via dependencies/<name>.cmake), and the
+# return() below needs to resume that loop -- return() from a function would
+# only exit the function itself, not resume the caller's foreach.
+macro(nwx_ecosystem_dependency ned_name ned_git_repository)
+    if(NWX_VENV_SITE_PACKAGES)
+        unset(${ned_name}_DIR CACHE)
+        find_package(${ned_name} CONFIG QUIET
+            PATHS "${NWX_VENV_SITE_PACKAGES}" NO_DEFAULT_PATH
+        )
+    endif()
+    if(TARGET nwx::${ned_name})
+        set(_gd_target_${ned_name} "nwx::${ned_name}")
+        list(APPEND _gd_targets nwx::${ned_name})
+        set(_gd_uses_fc FALSE)
+        return()
+    endif()
+
+    FetchContent_Declare(
+        ${ned_name}
+        GIT_REPOSITORY ${ned_git_repository}
+        GIT_TAG        master
+    )
+
+    list(APPEND _gd_targets ${ned_name})
+endmacro()

--- a/cmake/nwx_library.cmake
+++ b/cmake/nwx_library.cmake
@@ -54,6 +54,13 @@ function(nwx_library nl_project_name nl_inc_dir nl_src_dir)
     # nl_TYPE                = library type forwarded to add_library()
     # nl_NO_INSTALL          = skip install_library()
 
+    # Positional ecosystem deps must also be resolved: now that
+    # get_dependencies() can satisfy a dep via find_package() against an
+    # installed wheel instead of FetchContent, its real target is
+    # "nwx::<name>", not the bare short name -- so this can no longer assume
+    # short name == target name the way it could when every dep was
+    # unconditionally FetchContent'd in-tree.
+    _nwx_resolve_dep_names(_nl_eco       ${nl_UNPARSED_ARGUMENTS})
     _nwx_resolve_dep_names(_nl_pub_extra ${nl_PUBLIC})
     _nwx_resolve_dep_names(_nl_priv      ${nl_PRIVATE})
 
@@ -67,7 +74,7 @@ function(nwx_library nl_project_name nl_inc_dir nl_src_dir)
     if(__nl_source_files)
         add_library(${nl_project_name} ${nl_TYPE} ${__nl_source_files})
         target_link_libraries(${nl_project_name}
-            PUBLIC  ${nl_UNPARSED_ARGUMENTS} ${_nl_pub_extra}
+            PUBLIC  ${_nl_eco} ${_nl_pub_extra}
             PRIVATE ${_nl_priv}
         )
         target_include_directories(${nl_project_name}
@@ -103,7 +110,7 @@ function(nwx_library nl_project_name nl_inc_dir nl_src_dir)
         # dropped (the library has no TUs to compile against them).
         add_library(${nl_project_name} INTERFACE)
         target_link_libraries(${nl_project_name}
-            INTERFACE ${nl_UNPARSED_ARGUMENTS} ${_nl_pub_extra}
+            INTERFACE ${_nl_eco} ${_nl_pub_extra}
         )
         target_include_directories(${nl_project_name}
             INTERFACE

--- a/cmake/nwx_python_module.cmake
+++ b/cmake/nwx_python_module.cmake
@@ -39,6 +39,12 @@ function(nwx_python_module nwx_python_module_name nwx_python_src_dir)
     # pybind11 v3 builds extensions via python_add_library, which is provided by
     # the modern FindPython module's Development.Module component.
     find_package(Python REQUIRED COMPONENTS Interpreter Development.Module)
+    # DEPENDS may name an ecosystem dep (e.g. "parallelzone") whose real
+    # target is only known via NWX_DEP_TARGET_<name> -- it can be
+    # "nwx::parallelzone" (found via find_package against an installed
+    # wheel) rather than the bare short name (FetchContent'd in-tree).
+    include(nwx_library)
+    _nwx_resolve_dep_names(npm_DEPENDS ${npm_DEPENDS})
     file(
         GLOB_RECURSE __nwx_python_module_source_files
         CONFIGURE_DEPENDS ${nwx_python_src_dir}/*.cpp


### PR DESCRIPTION
Title. The old dependency files didn't try to locate the dependencies and always built them.