### PR TITLE
Guard against re-fetching an ecosystem dep that's already the top-level project

### DIFF
--- a/cmake/nwx_ecosystem_dependency.cmake
+++ b/cmake/nwx_ecosystem_dependency.cmake
@@ -52,6 +52,17 @@ macro(nwx_ecosystem_dependency ned_name ned_git_repository)
         list(APPEND _gd_targets nwx::${ned_name})
         set(_gd_uses_fc FALSE)
         return()
+    elseif(TARGET ${ned_name})
+        # ${ned_name} is already a real target -- e.g. this repo is the
+        # top-level project (built via nwx_library(), which defines the bare
+        # name, not an nwx:: alias) and is also, transitively, its own
+        # ecosystem dependency (INTEGRATION_TESTING pulling in a superproject
+        # that depends back on this repo). Re-fetching would redefine the
+        # same target and fail with a duplicate-target CMake error.
+        set(_gd_target_${ned_name} "${ned_name}")
+        list(APPEND _gd_targets ${ned_name})
+        set(_gd_uses_fc FALSE)
+        return()
     endif()
 
     FetchContent_Declare(


### PR DESCRIPTION
## Summary
- \`nwx_ecosystem_dependency()\` only skipped re-fetching a dependency when the \`nwx::<name>\` alias target already existed (the case where the dep was resolved via \`find_package()\` against an installed wheel).
- It missed the case where \`<name>\` is already a **bare** target because this repo *is* that dependency's top-level project — built directly via \`nwx_library()\`, which never defines the \`nwx::\` alias — and is also, transitively, its own ecosystem dependency. E.g. SCF built with \`-DINTEGRATION_TESTING=ON\` pulls in the \`nwchemex\` superproject, which itself depends on \`scf\`. FetchContent would then re-fetch and redefine the same target, and CMake would fail:
  ```
  add_library cannot create target "scf" because another target with the
  same name already exists.
  ```
  This broke \`test_cmake_build\` on **every** platform for [NWChemEx/SCF#70](https://github.com/NWChemEx/SCF/pull/70) — unrelated to that PR's actual (and successful) macOS pybind11 segfault fix.
- Fix: also short-circuit on \`TARGET ${ned_name}\` (the bare name), same as the existing \`nwx::${ned_name}\` branch.

This affects every ecosystem repo that routes through this shared macro (\`chemcache\`, \`chemist\`, \`integrals\`, \`parallelzone\`, \`pluginplay\`, \`nux\`, \`nwchemex\`, \`scf\`, \`simde\`, \`tensorwrapper\`, \`utilities\`) whenever it's both a dependency of another ecosystem repo and built with \`INTEGRATION_TESTING=ON\`.

## Test plan
- [x] Minimal standalone CMake repro mirroring \`get_dependencies.cmake\`'s \`FetchContent_MakeAvailable\` call:
  - With a pre-existing bare target and the old guard: falls through to \`FetchContent\`, fails trying to clone a bogus URL (reproduces the bug).
  - With the fix: short-circuits before ever reaching \`FetchContent\` — no network attempt, clean configure.
  - Regression check: with **no** pre-existing target (normal, first-time ecosystem fetch), the new branch does not fire — falls through to \`FetchContent\` exactly as before.
- [ ] Once merged, SCF PR #70's \`test_cmake_build\` should pass on all legs (it FetchContents NWXCMake unpinned from \`master\`, so this picks up automatically).

🤖 Generated with [Claude Code](https://claude.com/claude-code)