### PR TITLE
Disable ccache for libxc's targets

### DIFF
--- a/cmake/dependencies/libxc.cmake
+++ b/cmake/dependencies/libxc.cmake
@@ -52,6 +52,25 @@ FetchContent_MakeAvailable(libxc)
 set(BUILD_TESTING "${_gd_bt_backup}" CACHE BOOL "" FORCE)
 unset(_gd_bt_backup)
 
+# Skip ccache for libxc specifically. A ccache entry for one of its object
+# files was found corrupted/truncated (from a prior cancelled or OOM-killed
+# CI run, most likely) and served as a false hit, producing a binary that
+# built and linked cleanly but crashed with SIGILL at runtime deep inside a
+# libxc functional evaluation -- reproduced, and confirmed fixed by manually
+# clearing the ccache entry, on NWChemEx/SCF#70. libxc's own build is fast
+# (a few seconds) and FetchContent already caches its source checkout
+# separately, so losing ccache's object-level reuse here is cheap insurance
+# against that class of bug recurring silently.
+foreach(_lxc_target xc xcf03)
+    if(TARGET ${_lxc_target})
+        set_target_properties(${_lxc_target} PROPERTIES
+            C_COMPILER_LAUNCHER ""
+            CXX_COMPILER_LAUNCHER ""
+        )
+    endif()
+endforeach()
+unset(_lxc_target)
+
 # libxc's CMakeLists only defines the plain "xc" target; "Libxc::xc" is an
 # imported-target alias created by its install(EXPORT) rule, which doesn't
 # exist for an in-tree FetchContent build (same situation as gau2grid's "gg").


### PR DESCRIPTION
## Summary
- A ccache entry for one of libxc's object files was found corrupted/truncated (most likely from a prior cancelled or OOM-killed CI run) and served as a false hit: it built and linked cleanly but crashed with `SIGILL` at runtime deep inside a libxc functional evaluation (`test_unit_scf`/`test_integration_scf`'s libxc SVWN3 tests, seen intermittently on [NWChemEx/SCF#70](https://github.com/NWChemEx/SCF/pull/70)'s `test_cmake_build (ubuntu-latest, gcc-14)` leg).
- Reproduced and confirmed: a from-scratch build (no ccache) never crashed; manually deleting the `ccache-Linux-gcc-14-*` GitHub Actions cache and re-running fixed the real PR job. Root cause is a bad cache entry, not libxc's source, GCC, or CPU/ISA.
- The corrupted entry has since been cleared manually, but the underlying risk remains: ccache is reused across CI runs (and potentially different physical hosts) via a restore-key fallback, so this class of bug can recur silently.
- Fix: clear `C_COMPILER_LAUNCHER`/`CXX_COMPILER_LAUNCHER` on libxc's targets (`xc`, and `xcf03` if Fortran bindings are enabled) right after `FetchContent_MakeAvailable(libxc)`, so this one dependency is never routed through ccache. Its own build is a few seconds, and FetchContent already caches the source checkout separately, so the object-level reuse given up here is cheap insurance.

## Test plan
- [x] Minimal local repro confirming `set_target_properties(<tgt> PROPERTIES C_COMPILER_LAUNCHER "")` after `add_library` correctly drops the `LAUNCHER` from that target's Ninja compile rule while a sibling target keeps the global launcher.
- [ ] Once merged, SCF PR #70 should no longer be able to hit this SIGILL class of failure regardless of ccache state.

🤖 Generated with [Claude Code](https://claude.com/claude-code)