### PR TITLE
Honor CMAKE_PREFIX_PATH when resolving libint2/gauxc/libxc/gau2grid

### DIFF
--- a/cmake/dependencies/gau2grid.cmake
+++ b/cmake/dependencies/gau2grid.cmake
@@ -15,11 +15,25 @@
 include_guard()
 include(FetchContent)
 
-# Reuse a previously-installed copy from the active venv's site-packages
-# (NWX_VENV_SITE_PACKAGES, set by get_skbuild_python_path()) if one exists,
-# instead of re-cloning and rebuilding gau2grid from source every time.
-# Scoped to exactly that directory (NO_DEFAULT_PATH) so this can never
-# accidentally match an unrelated system-wide install (e.g. Homebrew).
+# Resolution order: (1) a pre-installed copy reachable via the caller's own
+# CMAKE_PREFIX_PATH (e.g. a hand-built or system-package gau2grid), (2) a
+# previous build's copy already installed into the active venv's
+# site-packages (NWX_VENV_SITE_PACKAGES, set by get_skbuild_python_path()),
+# (3) fetch and build from source. CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY is
+# already forced ON globally (get_dependencies.cmake), so step (1) can't
+# resolve against a stale ~/.cmake/packages entry -- only CMAKE_PREFIX_PATH
+# and the normal default search locations.
+find_package(gau2grid CONFIG QUIET)
+if(TARGET gau2grid::gg)
+    set(_gd_target_gau2grid "gau2grid::gg")
+    set(_gd_uses_fc FALSE)
+    return()
+endif()
+
+# Step (2): reuse a previous build's copy instead of re-cloning and
+# rebuilding gau2grid from source every time. Scoped to exactly that
+# directory (NO_DEFAULT_PATH) so this can never accidentally match an
+# unrelated system-wide install (e.g. Homebrew).
 if(NWX_VENV_SITE_PACKAGES)
     # GauXC's own (unrelated, unscoped) internal find_package(gau2grid) call
     # for its own grid-generation code can leave a stale/negative

--- a/cmake/dependencies/gauxc.cmake
+++ b/cmake/dependencies/gauxc.cmake
@@ -15,12 +15,26 @@
 include_guard()
 include(FetchContent)
 
-# If a previous build already installed gauxc into the active venv's
+# Resolution order: (1) a pre-installed copy reachable via the caller's own
+# CMAKE_PREFIX_PATH (e.g. a hand-built or system-package GauXC), (2) a
+# previous build's copy already installed into the active venv's
 # site-packages (NWX_VENV_SITE_PACKAGES, set by get_skbuild_python_path()),
-# reuse it instead of re-cloning and rebuilding GauXC (and its own
-# transitively-fetched ExchCXX/IntegratorXX/libxc) from source every time.
-# Scoped to exactly that directory (NO_DEFAULT_PATH) so this can never
-# accidentally match an unrelated system-wide install (e.g. Homebrew).
+# (3) fetch and build from source. CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY is
+# already forced ON globally (get_dependencies.cmake), so step (1) can't
+# resolve against a stale ~/.cmake/packages entry -- only CMAKE_PREFIX_PATH
+# and the normal default search locations.
+find_package(gauxc CONFIG QUIET)
+if(TARGET gauxc::gauxc)
+    set(_gd_target_gauxc "gauxc::gauxc")
+    set(_gd_uses_fc FALSE)
+    return()
+endif()
+
+# Step (2): reuse a previous build's copy instead of re-cloning and
+# rebuilding GauXC (and its own transitively-fetched ExchCXX/IntegratorXX/
+# libxc) from source every time. Scoped to exactly that directory
+# (NO_DEFAULT_PATH) so this can never accidentally match an unrelated
+# system-wide install (e.g. Homebrew).
 if(NWX_VENV_SITE_PACKAGES)
     # GauXC's own (unrelated, unscoped) internal find_package() calls for its
     # own transitive deps can leave a stale/negative <Pkg>_DIR cache entry

--- a/cmake/dependencies/libint2.cmake
+++ b/cmake/dependencies/libint2.cmake
@@ -15,6 +15,21 @@
 include_guard()
 include(FetchContent)
 
+# Reuse a pre-installed copy reachable via the caller's own CMAKE_PREFIX_PATH
+# (e.g. a hand-built or system-package libint2) instead of fetching and
+# building from source. CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY is already
+# forced ON globally (get_dependencies.cmake), so this can't resolve against
+# a stale ~/.cmake/packages entry -- only CMAKE_PREFIX_PATH and the normal
+# default search locations. Unlike gauxc/libxc/gau2grid, libint2 isn't
+# pip-installed into the venv by this ecosystem, so there's no second,
+# venv-scoped attempt to make here.
+find_package(Libint2 CONFIG QUIET)
+if(TARGET Libint2::int2)
+    set(_gd_target_libint2 "Libint2::int2")
+    set(_gd_uses_fc FALSE)
+    return()
+endif()
+
 # Libint2 builds a real (compiled) library from its own CMakeLists. Disable the
 # parts we don't use before add_subdirectory. CACHE FORCE so our values win over
 # the subproject's option() defaults (policy CMP0077).

--- a/cmake/dependencies/libxc.cmake
+++ b/cmake/dependencies/libxc.cmake
@@ -15,11 +15,25 @@
 include_guard()
 include(FetchContent)
 
-# Reuse a previously-installed copy from the active venv's site-packages
-# (NWX_VENV_SITE_PACKAGES, set by get_skbuild_python_path()) if one exists,
-# instead of re-cloning and rebuilding libxc from source every time. Scoped
-# to exactly that directory (NO_DEFAULT_PATH) so this can never accidentally
-# match an unrelated system-wide install (e.g. Homebrew).
+# Resolution order: (1) a pre-installed copy reachable via the caller's own
+# CMAKE_PREFIX_PATH (e.g. a hand-built or system-package libxc), (2) a
+# previous build's copy already installed into the active venv's
+# site-packages (NWX_VENV_SITE_PACKAGES, set by get_skbuild_python_path()),
+# (3) fetch and build from source. CMAKE_FIND_PACKAGE_NO_PACKAGE_REGISTRY is
+# already forced ON globally (get_dependencies.cmake), so step (1) can't
+# resolve against a stale ~/.cmake/packages entry -- only CMAKE_PREFIX_PATH
+# and the normal default search locations.
+find_package(Libxc CONFIG QUIET)
+if(TARGET Libxc::xc)
+    set(_gd_target_libxc "Libxc::xc")
+    set(_gd_uses_fc FALSE)
+    return()
+endif()
+
+# Step (2): reuse a previous build's copy instead of re-cloning and
+# rebuilding libxc from source every time. Scoped to exactly that directory
+# (NO_DEFAULT_PATH) so this can never accidentally match an unrelated
+# system-wide install (e.g. Homebrew).
 if(NWX_VENV_SITE_PACKAGES)
     # A dependency fetched earlier in this same configure (e.g. GauXC, which
     # transitively fetches its own libxc) can leave a stale/negative


### PR DESCRIPTION
find_package() for gauxc/libxc/gau2grid was scoped with NO_DEFAULT_PATH to only the active venv's site-packages, so a caller-supplied CMAKE_PREFIX_PATH pointing at a pre-installed copy was never consulted; libint2 had no find_package() attempt at all and always fetched from source. Add an unscoped find_package() first (honors CMAKE_PREFIX_PATH), falling back to the venv-scoped lookup and then FetchContent as before.

